### PR TITLE
Fixed N_REPLICA config params error

### DIFF
--- a/gridnetwork/routes/network.py
+++ b/gridnetwork/routes/network.py
@@ -95,17 +95,29 @@ def delete_grid_node():
 @http.route("/choose-encrypted-model-host", methods=["GET"])
 def choose_encrypted_model_host():
     """Choose grid nodes to host an encrypted model (currently the choice is random)."""
-    grid_nodes = network_manager.connected_nodes()
-    n_replica = current_app.config.get("N_REPLICA", 1)
+    hosts_info = []
+    response_body = {"message": None}
+    status_code = None
 
     try:
+        grid_nodes = network_manager.connected_nodes()
+        n_replica = current_app.config.get("N_REPLICA", 1)
+
         hosts = random.sample(list(grid_nodes.keys()), n_replica * SMPC_HOST_CHUNK)
         hosts_info = [(host, grid_nodes[host]) for host in hosts]
+
+        response_body = hosts_info
+        status_code = 200
+
     # If grid network doesn't have enough grid nodes
     except ValueError:
-        hosts_info = []
+        response_body = hosts_info
+        status_code = 400        
+    except Exception as e:
+        response_body["message"] = str(e)
+        status_code = 500  # Internal Server Error
 
-    return Response(json.dumps(hosts_info), status=200, mimetype="application/json")
+    return Response(json.dumps(response_body), status=status_code, mimetype="application/json")
 
 
 @http.route("/choose-model-host", methods=["GET"])

--- a/gridnetwork/routes/network.py
+++ b/gridnetwork/routes/network.py
@@ -96,10 +96,8 @@ def delete_grid_node():
 def choose_encrypted_model_host():
     """Choose grid nodes to host an encrypted model (currently the choice is random)."""
     grid_nodes = network_manager.connected_nodes()
-    n_replica = current_app.config["N_REPLICA"]
+    n_replica = current_app.config.get("N_REPLICA", 1)
 
-    if not n_replica:
-        n_replica = 1
     try:
         hosts = random.sample(list(grid_nodes.keys()), n_replica * SMPC_HOST_CHUNK)
         hosts_info = [(host, grid_nodes[host]) for host in hosts]

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -205,3 +205,27 @@ def test_search_internal_server_error(mock_network_manager, client):
 
     assert result.status_code == 500
     assert result.get_json().get("message") == "test"
+
+@patch("gridnetwork.routes.network.network_manager")
+def test_choose_encrypted_model_host_value_error(mock_network_manager, client):
+    """
+    assert that the endpoint returns a 400 for value error
+    """
+    mock_network_manager.connected_nodes.return_value = {}
+
+    result = client.get("/choose-encrypted-model-host")
+    
+    assert result.status_code == 400
+    assert len(result.get_json()) == 0
+
+@patch("gridnetwork.routes.network.network_manager")
+def test_choose_encrypted_model_host_internal_server_error(mock_network_manager, client):
+    """
+    assert that the endpoint returns a 500 for an unknown error condition
+    """
+    mock_network_manager.connected_nodes.side_effect = RuntimeError("test")
+
+    result = client.get("/choose-encrypted-model-host")
+    
+    assert result.status_code == 500
+    assert result.get_json().get("message") == "test"


### PR DESCRIPTION
1. set default value for config object(dict) if key doesn't exist.

## Description
Tutorial: Grid as a Secure MLaaS

While serving the model, this error is thrown:
JSONDecodeError: Expecting value: line 1 column 1 (char 0)

in line:
cloud_grid_service.serve_model(model,id=model.id,allow_remote_inference=True, mpc=True)

closes #45 

## How has this been tested?
- The .serve_model() executes without error. 
- The param is set to 1 when the "N_REPLICA" key is not set in config object.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests (Does not Apply)
